### PR TITLE
Supports server-side paging.

### DIFF
--- a/src/Data/Data.csproj
+++ b/src/Data/Data.csproj
@@ -15,4 +15,8 @@
     </PackageReference>
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Model\Model.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Data/Model/Address.cs
+++ b/src/Data/Model/Address.cs
@@ -2,7 +2,7 @@
 
 namespace Data.Model
 {
-    public sealed class Address
+    public class Address
     {
         public long Id { get; set; }
 
@@ -19,6 +19,6 @@ namespace Data.Model
 
         // navigation properties
 
-        public Profile Profile { get; set; }
+        public virtual Profile Profile { get; set; }
     }
 }

--- a/src/Data/Model/Profile.cs
+++ b/src/Data/Model/Profile.cs
@@ -3,8 +3,13 @@ using System.Collections.Generic;
 
 namespace Data.Model
 {
-    public sealed class Profile
+    public class Profile
     {
+        public Profile()
+        {
+            Addresses = new HashSet<Address>();
+        }
+
         public string Id { get; set; }
 
         public string DisplayName { get; set; }
@@ -13,6 +18,6 @@ namespace Data.Model
         public DateTime CreatedUtc { get; set; }
 
         // navigation properties
-        public ICollection<Address> Addresses { get; set; }
+        public virtual ICollection<Address> Addresses { get; set; }
     }
 }

--- a/src/Model/CreateMaskedEmailRequest.cs
+++ b/src/Model/CreateMaskedEmailRequest.cs
@@ -1,16 +1,10 @@
 ﻿namespace Model
 {
-    public sealed class MaskedEmailRequest
+    public sealed class CreateMaskedEmailRequest
     {
         public string Name { get; set; }
         public string Description { get; set; }
         public string PasswordHash { get; set; }
         public bool EnableForwarding { get; set; }
-    }
-
-    public sealed class UpdateMaskedEmailRequest
-    { 
-        public string Name { get; set; }
-        public string Description { get; set; }
     }
 }

--- a/src/Model/GetMaskedEmailPagesResponse.cs
+++ b/src/Model/GetMaskedEmailPagesResponse.cs
@@ -1,0 +1,10 @@
+﻿namespace Model
+{
+    public sealed class GetMaskedEmailPageResponse
+    { 
+        public int Count { get; set; }
+        public int Total { get; set; }
+        public string Cursor { get; set; }
+        public MaskedEmail[] Addresses { get; set; }
+    }
+}

--- a/src/Model/UpdateMaskedEmailRequest.cs
+++ b/src/Model/UpdateMaskedEmailRequest.cs
@@ -1,0 +1,8 @@
+﻿namespace Model
+{
+    public sealed class UpdateMaskedEmailRequest
+    { 
+        public string Name { get; set; }
+        public string Description { get; set; }
+    }
+}

--- a/src/WebApi/Controllers/ProfilesController.cs
+++ b/src/WebApi/Controllers/ProfilesController.cs
@@ -62,7 +62,7 @@ namespace WebApi.Controllers
 
         // POST profiles/my/addresses
         [HttpPost("my/addresses/")]
-        public async Task<ActionResult> CreateMaskedEmail([FromBody] MaskedEmailRequest request)
+        public async Task<ActionResult> CreateMaskedEmail([FromBody] CreateMaskedEmailRequest request)
         {
             if (!GetAuthenticatedUserId(out var identifier))
                 return BadRequest();
@@ -73,6 +73,19 @@ namespace WebApi.Controllers
 
             // TODO: 201
             return Ok(address);
+        }
+
+        // GET profiles/my/adresses/pages
+        [HttpGet("my/address-pages")]
+        public async Task<ActionResult> GetMaskedEmailsPaging(int top = 2, string cursor = null, string sort_by = "created-utc-desc")
+        {
+            if (!GetAuthenticatedUserId(out var identifier))
+                return BadRequest();
+
+            var page = await service_
+                .GetMaskedEmails(identifier, top, cursor, sort_by, search: null);
+
+            return Ok(page);
         }
 
         // GET profiles/my/adresses

--- a/src/WebApi/Controllers/ProfilesController.cs
+++ b/src/WebApi/Controllers/ProfilesController.cs
@@ -76,8 +76,21 @@ namespace WebApi.Controllers
         }
 
         // GET profiles/my/adresses/pages
+        [HttpGet("my/search")]
+        public async Task<ActionResult> SearchMaskedEmails(string contains, int top = 25, string cursor = null, string sort_by = "created-utc-desc")
+        {
+            if (!GetAuthenticatedUserId(out var identifier))
+                return BadRequest();
+
+            var page = await service_
+                .GetMaskedEmails(identifier, top, cursor, sort_by, search: contains);
+
+            return Ok(page);
+        }
+
+        // GET profiles/my/adresses/pages
         [HttpGet("my/address-pages")]
-        public async Task<ActionResult> GetMaskedEmailsPaging(int top = 2, string cursor = null, string sort_by = "created-utc-desc")
+        public async Task<ActionResult> GetMaskedEmailsPaging(int top = 25, string cursor = null, string sort_by = "created-utc-desc")
         {
             if (!GetAuthenticatedUserId(out var identifier))
                 return BadRequest();

--- a/src/WebApi/Owin/ExceptionHandlingOptions.cs
+++ b/src/WebApi/Owin/ExceptionHandlingOptions.cs
@@ -11,6 +11,7 @@ namespace WebApi.Owin
             StatusCodes = new Dictionary<Type, HttpStatusCode>
             {
                 {typeof(KeyNotFoundException), HttpStatusCode.NotFound},
+                {typeof(ArgumentException), HttpStatusCode.BadRequest },
             };
         }
 

--- a/src/WebApi/Services/Interop/IProfilesService.cs
+++ b/src/WebApi/Services/Interop/IProfilesService.cs
@@ -11,6 +11,7 @@ namespace WebApi.Services.Interop
         Task<User> UpdateProfile(string userId, string displayName, string forwardingAddress);
 
         Task<IEnumerable<MaskedEmail>> GetMaskedEmails(string userId);
+        Task<GetMaskedEmailPageResponse> GetMaskedEmails(string userId, int top, string cursor, string sort_by, string search);
         Task<MaskedEmail> GetMaskedEmail(string userId, string email);
 
         Task<MaskedEmail> ToggleMaskedEmailForwarding(string userId, string email);

--- a/src/WebApi/Services/ProfilesService.cs
+++ b/src/WebApi/Services/ProfilesService.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Data;
 using Data.Interop;
@@ -22,6 +24,8 @@ namespace WebApi.Services
         private readonly IUniqueIdGenerator generator_;
         private readonly IMaskedEmailCommandService commands_;
         private readonly IOptions<AppSettings> settings_;
+
+        private const string ISO8601_DATE_TIME_FORMAT = "yyyy-MM-ddTHH:mm:ss.fffffff";
 
         public ProfilesService(IMaskedEmailsDbContext context, IUniqueIdGenerator generator, IMaskedEmailCommandService commands, IOptions<AppSettings> settings)
         {
@@ -72,6 +76,51 @@ namespace WebApi.Services
             var collection = record.Addresses.Select(a => a.ToModel());
 
             return collection;
+        }
+
+        public async Task<GetMaskedEmailPageResponse> GetMaskedEmails(string userId, int top, string cursor, string sort_by, string search_like)
+        {
+            var descending = (sort_by.EndsWith("-desc"));
+            if (descending)
+            {
+                sort_by = sort_by.Substring(0, sort_by.Length - "-desc".Length);
+            }
+
+            var when = ParseCursor(cursor, descending);
+
+            var record = await GetProfileEntityGraphForUpdate(userId);
+            if (record == null)
+                throw Error.NoSuchProfile(userId);
+
+            var collection = context_.Addresses
+                .Where(a => a.Profile == record)
+                .OrderBy(sort_by, descending)
+                ;
+
+            var response = new GetMaskedEmailPageResponse
+            {
+                Total = await collection.CountAsync(),
+            };
+
+            var expression = MakeSelectPageExpression(when, descending);
+
+            collection = collection
+                .Where(expression)
+                .Take(top)
+                ;
+
+            var array = await collection
+                .Select(a => a.ToModel())
+                .ToArrayAsync()
+                ;
+
+            response.Addresses = array;
+            response.Count = array.Length;
+
+            if (array.Length > 0)
+                response.Cursor = MakeCursor(array[^1].CreatedUtc);
+
+            return response;
         }
 
         public async Task<MaskedEmail> GetMaskedEmail(string userId, string email)
@@ -146,7 +195,7 @@ namespace WebApi.Services
         }
 
         public async Task UpdateMaskedEmail(string userId, string email, string name, string description)
-        { 
+        {
             var address = await GetAddressEntityForUpdate(userId, email);
 
             if (!string.IsNullOrEmpty(name) && address.Name != name)
@@ -201,6 +250,7 @@ namespace WebApi.Services
             return
                 await QueryProfileEntities()
                     .Include(e => e.Addresses)
+                    .ThenInclude(a => a.Profile)
                     .SingleOrDefaultAsync(p => p.Id == userId)
                 ;
         }
@@ -219,6 +269,40 @@ namespace WebApi.Services
         }
 
         #endregion
+
+        private DateTime ParseCursor(string cursor, bool descending)
+        {
+            // cursor is an ISO-8601 date
+
+            DateTime when = DateTime.MinValue;
+            if (String.IsNullOrEmpty(cursor))
+            {
+                if (descending)
+                    when = DateTime.MaxValue;
+            }
+            else
+            {
+                if (!DateTime.TryParseExact(cursor, ISO8601_DATE_TIME_FORMAT, CultureInfo.InvariantCulture, DateTimeStyles.None, out when))
+                    throw new ArgumentException("Invalid cursor syntax.");
+            }
+
+            return when;
+        }
+
+        private string MakeCursor(DateTime createdUtc)
+        {
+            return createdUtc.ToString(ISO8601_DATE_TIME_FORMAT);
+        }
+
+        private static Expression<Func<Address, bool>> MakeSelectPageExpression(DateTime when, bool descending)
+        {
+            Expression<Func<Address, bool>> where =
+                a => a.CreatedUtc > when;
+            if (descending)
+                where = a => a.CreatedUtc < when;
+
+            return where;
+        }
 
         private string MakePassword()
         {

--- a/src/WebApi/Services/QueryableExtensions.cs
+++ b/src/WebApi/Services/QueryableExtensions.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Linq;
+using Data.Model;
+
+namespace WebApi.Services
+{
+    internal static class QueryableExtensions
+    { 
+        public static IQueryable<Address> OrderBy(this IQueryable<Address> collection, string sort_by, bool descending)
+        { 
+            if (sort_by == "address")
+            {
+                collection = descending
+                        ? collection.OrderByDescending(a => a.EmailAddress)
+                        : collection.OrderBy(a => a.EmailAddress)
+                        ;
+            }
+            else if (sort_by == "created-utc")
+            {
+                collection = descending
+                        ? collection.OrderByDescending(a => a.CreatedUtc)
+                        : collection.OrderBy(a => a.CreatedUtc)
+                        ;
+            }
+            else if (sort_by == "name")
+            {
+                collection = descending
+                        ? collection.OrderByDescending(a => a.Name)
+                        : collection.OrderBy(a => a.Name)
+                        ;
+            }
+            else if (sort_by == "description")
+            {
+                collection = descending
+                        ? collection.OrderByDescending(a => a.Description)
+                        : collection.OrderBy(a => a.Name)
+                        ;
+            }
+            else
+            {
+                throw new ArgumentException($"Unsupported sort criteria '{sort_by}'.");
+            }
+
+            return collection;
+        }
+    }
+}

--- a/src/masked-emails/Client/IMaskedEmailsApi.cs
+++ b/src/masked-emails/Client/IMaskedEmailsApi.cs
@@ -14,7 +14,7 @@ namespace masked_emails.Client
 
         [Post("/profiles/my/addresses")]
         [Headers("Authorization: Bearer")]
-        Task<MaskedEmailWithPassword> CreateAddress([Body] MaskedEmailRequest request);
+        Task<MaskedEmailWithPassword> CreateAddress([Body] CreateMaskedEmailRequest request);
 
         [Get("/profiles/my/addresses")]
         [Headers("Authorization: Bearer")]

--- a/src/masked-emails/Client/MaskedEmailsClient.cs
+++ b/src/masked-emails/Client/MaskedEmailsClient.cs
@@ -25,7 +25,7 @@ namespace masked_emails.Client
             return client_.GetProfileAsync();
         }
 
-        public Task<MaskedEmailWithPassword> CreateAddress(MaskedEmailRequest request)
+        public Task<MaskedEmailWithPassword> CreateAddress(CreateMaskedEmailRequest request)
         {
             return client_.CreateAddress(request);
         }

--- a/src/masked-emails/Commands/CreateMaskedEmailAddressCommand.cs
+++ b/src/masked-emails/Commands/CreateMaskedEmailAddressCommand.cs
@@ -19,7 +19,7 @@ namespace masked_emails.Commands
             if (cmdLine.ShowUsage)
                 return;
 
-            var request = new MaskedEmailRequest {
+            var request = new CreateMaskedEmailRequest {
                 Description = cmdLine.Description ?? "",
                 EnableForwarding = true,
                 Name = cmdLine.Name,


### PR DESCRIPTION
A new API is available:

```
GET /profiles/my/address-pages?top=<int>[&sort_by=<sort>][&cursor=<next>]
```
Where:
- `top` : limits the amount of records retrieved in a single page.
- `sort_by` : is the sort criteria. One of `name[-desc]` | `address[-desc]` | `description[-desc]` | `created-utc[-desc]`.
- `cursor` : is a string that is retrieved by the previous call, use to retrieve the next page.

